### PR TITLE
Make git ignore execuatbles and other binary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,45 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+#-----------------------
+
+bin/
+
+# ----------------------
+
+# Created by https://www.gitignore.io/api/c++
+
+### C++ ###
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app


### PR DESCRIPTION
Instead of in your open source repository, consider putting them (/bin/wurst) in a separate version